### PR TITLE
Translate sec-edgar module from Python to C#

### DIFF
--- a/RAG-GPT-Insight/ASAP-SEC-RAG-Navigator/SEC-EDGAR-Navigator/CompanyInfo.cs
+++ b/RAG-GPT-Insight/ASAP-SEC-RAG-Navigator/SEC-EDGAR-Navigator/CompanyInfo.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+public class CompanyInfo
+{
+    private List<Dictionary<string, string>> records;
+    private List<string> fields;
+
+    public CompanyInfo(string jsonPath)
+    {
+        using (StreamReader file = File.OpenText(jsonPath))
+        using (JsonTextReader reader = new JsonTextReader(file))
+        {
+            JObject data = (JObject)JToken.ReadFrom(reader);
+            fields = data["fields"].ToObject<List<string>>();
+            records = data["data"].ToObject<List<Dictionary<string, string>>>();
+        }
+    }
+
+    public List<Dictionary<string, string>> ToDataFrame()
+    {
+        return records;
+    }
+
+    public string GetCikByTicker(string ticker)
+    {
+        foreach (var record in records)
+        {
+            if (record["ticker"] == ticker)
+            {
+                return record["cik"];
+            }
+        }
+        throw new Exception($"No company found with ticker: {ticker}");
+    }
+
+    public List<Dictionary<string, string>> SearchByName(string substring)
+    {
+        List<Dictionary<string, string>> result = new List<Dictionary<string, string>>();
+        foreach (var record in records)
+        {
+            if (record["name"].IndexOf(substring, StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                result.Add(record);
+            }
+        }
+        return result;
+    }
+}

--- a/RAG-GPT-Insight/ASAP-SEC-RAG-Navigator/SEC-EDGAR-Navigator/Program.cs
+++ b/RAG-GPT-Insight/ASAP-SEC-RAG-Navigator/SEC-EDGAR-Navigator/Program.cs
@@ -1,0 +1,64 @@
+using System;
+using System.IO;
+using Newtonsoft.Json.Linq;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        // Paths and setup
+        string datasetPath = "data/company_tickers_exchange.json";
+        string outputDir = "data";
+        Directory.CreateDirectory(outputDir);
+        string email = "your.email@example.com";
+
+        // Initialize components
+        CompanyInfo companyInfo = new CompanyInfo(datasetPath);
+        SECFilings secFilings = new SECFilings(email);
+
+        // Fetch company CIK by ticker
+        string ticker = "TSLA"; // TSLA, AAPL, NVDA, MSFT, AMZN, GOOGLE, META
+        try
+        {
+            string cik = companyInfo.GetCikByTicker(ticker);
+            Console.WriteLine($"CIK for {ticker}: {cik}");
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e.Message);
+            return;
+        }
+
+        // Fetch filing history
+        try
+        {
+            var filings = secFilings.GetCompanyFilings(cik);
+            var filingsDataFrame = secFilings.FilingsToDataFrame(filings);
+            Console.WriteLine(filingsDataFrame);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e.Message);
+            return;
+        }
+
+        // Download the latest 10-K report
+        var latest10K = filingsDataFrame.FirstOrDefault(f => f.Form == "10-K");
+        if (latest10K != null)
+        {
+            string accessionNumber = latest10K.AccessionNumber.Replace("-", "");
+            string fileName = latest10K.PrimaryDocument;
+            string savePath = Path.Combine(outputDir, $"{fileName}.html");
+
+            try
+            {
+                secFilings.DownloadDocument(cik, accessionNumber, fileName, savePath);
+                Console.WriteLine($"Downloaded 10-K to {savePath}");
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"Failed to download document: {e.Message}");
+            }
+        }
+    }
+}

--- a/RAG-GPT-Insight/ASAP-SEC-RAG-Navigator/SEC-EDGAR-Navigator/README.md
+++ b/RAG-GPT-Insight/ASAP-SEC-RAG-Navigator/SEC-EDGAR-Navigator/README.md
@@ -1,1 +1,65 @@
 # SEC-EDGAR-Navigator
+
+## Overview
+This project retrieves and processes financial data from the SEC EDGAR RESTful APIs. It includes functionality for:
+- Retrieving company CIKs by ticker.
+- Fetching filing histories.
+- Downloading specific filings.
+
+## Program.cs Documentation
+
+### Main Function
+The main function orchestrates the fetching and downloading of SEC filings for a given company ticker.
+
+### Variables
+- **datasetPath**: Path to the JSON file containing company tickers and exchange information.
+- **outputDir**: Directory where the downloaded files will be saved.
+- **email**: Email address used for SEC filings requests.
+- **companyInfo**: Instance of `CompanyInfo` initialized with the dataset path.
+- **secFilings**: Instance of `SECFilings` initialized with the email address.
+- **ticker**: Example ticker symbol for which the filings will be fetched.
+- **cik**: Central Index Key (CIK) fetched using the ticker symbol.
+- **filings**: Filing history fetched using the CIK.
+- **filingsDataFrame**: DataFrame containing the filing history.
+- **latest10K**: The latest 10-K filing from the filing history.
+- **accessionNumber**: Formatted accession number of the latest 10-K filing.
+- **fileName**: Name of the primary document in the latest 10-K filing.
+- **savePath**: Path where the latest 10-K filing will be saved.
+
+## Setup
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/your-repo/sec-edgar-navigator.git
+   ```
+2. Install dependencies:
+   ```bash
+   dotnet restore
+   ```
+
+## Usage
+Run the main script to fetch and process SEC EDGAR data:
+
+```bash
+dotnet run
+```
+
+## Features
+- Fetch a company's Central Index Key (CIK) by its ticker symbol.
+- Search for companies by name substring.
+- Retrieve filing histories for a company using its CIK.
+- Download and save specific filings as HTML and PDF (requires WeasyPrint).
+
+## Requirements
+- .NET 6.0 or higher
+- Libraries in `SEC-EDGAR-Navigator.csproj`
+- Kaggle dataset file (`company_tickers_exchange.json`) containing company tickers, names, and exchanges.
+
+## Limitations
+- WeasyPrint requires system dependencies such as GTK, Cairo, and Pango. Make sure these are installed on your machine.
+- API calls to SEC EDGAR RESTful services must follow the SEC's fair use policy (maximum 10 requests per second).
+
+## Troubleshooting
+If you encounter issues with WeasyPrint, ensure the required libraries are installed on your system. Follow [WeasyPrint's installation guide](https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#installation).
+
+## License
+This project is licensed under the MIT License. See the LICENSE file for details.

--- a/RAG-GPT-Insight/ASAP-SEC-RAG-Navigator/SEC-EDGAR-Navigator/SECFilings.cs
+++ b/RAG-GPT-Insight/ASAP-SEC-RAG-Navigator/SEC-EDGAR-Navigator/SECFilings.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using WeasyPrint;
+
+public class SECFilings
+{
+    private static readonly HttpClient client = new HttpClient();
+    private readonly string email;
+
+    public SECFilings(string email)
+    {
+        this.email = email;
+        client.DefaultRequestHeaders.Add("User-Agent", email);
+    }
+
+    public async Task<JObject> GetCompanyFilings(string cik)
+    {
+        string url = $"https://data.sec.gov/submissions/CIK{cik}.json";
+        HttpResponseMessage response = await client.GetAsync(url);
+        if (response.IsSuccessStatusCode)
+        {
+            string content = await response.Content.ReadAsStringAsync();
+            return JObject.Parse(content);
+        }
+        else
+        {
+            throw new Exception($"Failed to fetch data for CIK {cik}: {response.StatusCode}");
+        }
+    }
+
+    public List<Dictionary<string, string>> FilingsToDataFrame(JObject filings)
+    {
+        var recentFilings = filings["filings"]["recent"];
+        var filingsList = new List<Dictionary<string, string>>();
+
+        foreach (var filing in recentFilings)
+        {
+            var filingDict = new Dictionary<string, string>
+            {
+                { "form", filing["form"].ToString() },
+                { "accessionNumber", filing["accessionNumber"].ToString() },
+                { "primaryDocument", filing["primaryDocument"].ToString() }
+            };
+            filingsList.Add(filingDict);
+        }
+
+        return filingsList;
+    }
+
+    public async Task DownloadDocument(string cik, string accessionNumber, string fileName, string savePath)
+    {
+        string baseUrl = $"https://www.sec.gov/Archives/edgar/data/{cik}/{accessionNumber}/{fileName}";
+        string content = await client.GetStringAsync(baseUrl);
+
+        // Save the content as an HTML file
+        string htmlPath = savePath + ".html";
+        await File.WriteAllTextAsync(htmlPath, content);
+
+        // Convert HTML content to PDF using WeasyPrint
+        string pdfPath = savePath + ".pdf";
+        HTML(string: content, base_url: "").write_pdf(pdfPath);
+    }
+}


### PR DESCRIPTION
Related to #62

Translate the `sec-edgar` module from Python to C# and integrate it into the `SEC-EDGAR-Navigator` project.

* **Program.cs**: Implement the main function to fetch and download SEC filings. Initialize components, fetch company CIK by ticker, fetch filing history, and download the latest 10-K report.
* **CompanyInfo.cs**: Translate functionality from `company_info.py` to `CompanyInfo.cs`. Implement methods to fetch company CIK by ticker and search by name. Use JSON data to initialize company information.
* **SECFilings.cs**: Translate functionality from `filings.py` to `SECFilings.cs`. Implement methods to fetch company filings and download documents. Use WeasyPrint for PDF generation.
* **README.md**: Document the new C# project and its functionality. Include setup instructions and usage examples. Provide details on the main function and its variables.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/aitrailblazer/ASAPKnowledgeNavigator/pull/63?shareId=bb6266b5-c565-4d1d-8e9f-ef0f340156ec).