### PR TITLE
Add documentation for go-sec-edgar-ws

### DIFF
--- a/ASAPKnowledgeNavigator/ASAPKnowledgeNavigator.AppHost/go-sec-edgar-ws/README.md
+++ b/ASAPKnowledgeNavigator/ASAPKnowledgeNavigator.AppHost/go-sec-edgar-ws/README.md
@@ -1,17 +1,48 @@
+# go-sec-edgar-ws
 
-docker image prune -a --force
-docker network prune --force
+## Prerequisites
 
+Before you begin, ensure you have the following installed:
+
+- Docker
+- jq
+
+## Building the Docker Image
+
+To build the Docker image for `go-sec-edgar-ws`, run the following command:
+
+```bash
 docker build -t go-sec-edgar-ws .
-docker run -p 8000:8000 go-sec-edgar-ws
+```
 
+## Running the Docker Container
 
-curl -X POST http://localhost:8000/html-to-pdf \
+To run the Docker container, use the following command:
+
+```bash
+docker run -p 8001:8001 go-sec-edgar-ws
+```
+
+## Using the `/html-to-pdf` Endpoint
+
+You can convert HTML to PDF using the `/html-to-pdf` endpoint. Here are some example curl commands:
+
+```bash
+curl -X POST http://localhost:8001/html-to-pdf \
      -H "Content-Type: application/json" \
      -d @<(jq -Rs '{html: .}' < AAPL_10K.html) \
      -o AAPL_10K.pdf
 
-curl -X POST http://localhost:8000/html-to-pdf \
+curl -X POST http://localhost:8001/html-to-pdf \
      -H "Content-Type: application/json" \
      -d @<(jq -Rs '{html: .}' < TSLA_10K.html) \
      -o TSLA_10K.pdf
+```
+
+## Using the `/` Root Endpoint
+
+You can access the root endpoint to get a simple "Hello" response. Here is an example curl command:
+
+```bash
+curl http://localhost:8001/
+```


### PR DESCRIPTION
Related to #64

Add documentation for `go-sec-edgar-ws` in the `README.md`.

* **Prerequisites**
  - Add a section for prerequisites, including Docker and jq.

* **Building the Docker Image**
  - Add instructions for building the Docker image for `go-sec-edgar-ws`.

* **Running the Docker Container**
  - Add instructions for running the Docker container.

* **Using the `/html-to-pdf` Endpoint**
  - Add example curl commands for using the `/html-to-pdf` endpoint.

* **Using the `/` Root Endpoint**
  - Add example curl command for using the `/` root endpoint.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/aitrailblazer/ASAPKnowledgeNavigator/pull/65?shareId=d5f67774-6ef0-42c9-b1a1-50f9a6d53870).